### PR TITLE
Implemented some more features for bad variable names

### DIFF
--- a/styleChecker.sh
+++ b/styleChecker.sh
@@ -128,12 +128,13 @@ do
     #######################BAD VARIABLE NAMES##############
     #Catches when the variable is assigned. 
     #Catches single letter vars with numbers, ex. i1
+    #Updated: 5/28/15 21:11 (Purag Moumdjian)
     echo "Checking for 1 letter variable names."
 
     if (($verbose == 1)); then
-        grep -PinH "[;\s\(]([a-z])[\s\d]?=" $fileName 
+        grep -PinH "([a-z]+(\s?\[\])*\s)([a-z]([0-9]*)\s?(?=[;:=]))" $fileName 
     fi
-    localBadVarNames=$(grep -Pci "[;\s\(]([a-z])[\s\d]?=" $fileName)
+    localBadVarNames=$(grep -Pci "([a-z]+(\s?\[\])*\s)([a-z]([0-9]*)\s?(?=[;:=]))" $fileName)
     totalBadVarNames=$(($localBadVarNames + $totalBadVarNames))
     if (($localBadVarNames != 0)); then
         echo "** $localBadVarNames single-letter names in $fileName"


### PR DESCRIPTION
We can now catch:
- 1- or multi-dimensional arrays, as long as the array syntax is attached to the type name<br>(i.e. `Integer[][] someArray;`)
- single-character variable names followed by 0 or more digits
- variables create in a foreach loop (i.e. `for(Integer i : someArray)`)
